### PR TITLE
애플 실리콘 빌드 대응 - basePath가 잘못되어 수정

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "MailCore2",
-                      url: "https://github.com/worksmobile/mailcore2/tree/master/bin/MailCore2-2024-05-10.xcframework.zip",
+                      url: "https://github.com/worksmobile/mailcore2/tree/master-works/bin/MailCore2-2024-05-10.xcframework.zip",
                       checksum: "07cc79cc9469c68d41ff5645b3474f3b201a17cfc0406b436d6f4f9b8311738b")
     ]
 )

--- a/scripts/build-mailcore2-xcframework-spm.sh
+++ b/scripts/build-mailcore2-xcframework-spm.sh
@@ -12,7 +12,7 @@ DATE="`date +"%Y-%m-%d"`"
 FRAMEWORK_NAME="MailCore2.xcframework"
 ARCHIVE_NAME="MailCore2-$DATE.xcframework.zip"
 MANIFEST_PATH="$MAILCORE_DIR/Package.swift"
-BASE_URL="https://github.com/worksmobile/mailcore2/tree/master/bin"
+BASE_URL="https://github.com/worksmobile/mailcore2/tree/master-works/bin"
 FULL_URL="$BASE_URL/$ARCHIVE_NAME"
 SUCCESS_MESSAGE="
 -------------------


### PR DESCRIPTION
## 수정 사항
- `master-works`를 기준으로 versioning이 될 예정이므로 path 수정